### PR TITLE
Fixing logical errors to make full points on milestone 3 possible

### DIFF
--- a/script.js
+++ b/script.js
@@ -147,7 +147,7 @@ let fosterPet = [
     passesNeeded: 4,
     rubricPoints: 1,
     attributes: ["alt||aria-labelledby"],
-    styles: [["backgroundColor", "rgb (200, 200, 200)"]],
+    styles: [],
     levelUp: true,
     levelUpFeedback: `Level Up Detected \n All <imgs> have alt or aria-labelledby for screen reader accessabilty`,
   },
@@ -790,8 +790,8 @@ function checkAttribute(iteration, element, rubric) {
     }
     if (HTMLelement[k].hasAttribute(rubric.attributes[j]) == false) {
       if (rubric.levelUp == false) {
+        return false;
       }
-      return false;
     }
   }
   return true;

--- a/script.js
+++ b/script.js
@@ -780,9 +780,9 @@ function checkAttribute(iteration, element, rubric) {
   HTMLelement = document.querySelectorAll(element);
   for (let j = 0; j < rubric.attributes.length; j++) {
     if (rubric.attributes[j].indexOf("||") !== -1) {
-      rubric.attributes = rubric.attributes[j].split("||");
-      for (let i = 0; i < rubric.attributes.length; i++) {
-        if (HTMLelement[k].hasAttribute(rubric.attributes[i]) == true) {
+      let attributes = attributes[j].split("||");
+      for (let i = 0; i < attributes.length; i++) {
+        if (HTMLelement[k].hasAttribute(attributes[i]) == true) {
           return true;
         }
       }


### PR DESCRIPTION
While I ran the unit tests on my project to ensure I had gotten full points on all the content, some of the logical errors in the last rubric criteria for milestone 3 prevented me from getting all the extra credit.
```js
{
    elements: ["img"],
    passesNeeded: 4,
    rubricPoints: 1,
    attributes: ["alt||aria-labelledby"], // test fails, but not in the way expected
    styles: [["backgroundColor", "rgb (200, 200, 200)"]], // test fails, and will always fail no matter what
    levelUp: true,
    levelUpFeedback: `Level Up Detected \n All <imgs> have alt or aria-labelledby for screen reader accessabilty`,
}
```

Both the attributes and styles criteria will most likely fail on most complete projects, and there are different reasons for each.

Using `["alt||aria-labelledby"]` are intended to check alt text for images, and the logic means that either one will validate the element. However, the following code modifies the already existing rubric which changes the logic later:
```js
function checkAttribute(iteration, element, rubric) {
  k = iteration;
  elementForFeedBack = element;
  if (rubric.attributes === undefined) {
    return true;
  }
  HTMLelement = document.querySelectorAll(element);
  for (let j = 0; j < rubric.attributes.length; j++) {
    if (rubric.attributes[j].indexOf("||") !== -1) {
      rubric.attributes = rubric.attributes[j].split("||"); // <- This code will work correctly on the first iteration, but breaks later iterations
      for (let i = 0; i < rubric.attributes.length; i++) {
        if (HTMLelement[k].hasAttribute(rubric.attributes[i]) == true) {
          return true;
        }
      }
      return false;
    }
    if (HTMLelement[k].hasAttribute(rubric.attributes[j]) == false) {
      if (rubric.levelUp == false) {
       // This seems like a logical error, I assume the return statement is supposed to be here instead
      }
      return false;
    }
  }
  return true;
}
```

The second time, the attributes `["alt||aria-labelledby"]` now becomes `["alt", "aria-labelledby"]` which means that the element now needs BOTH of the attributes to succeed. This is the modified version of the function:

```js
function checkAttribute(iteration, element, rubric) {
  k = iteration;
  elementForFeedBack = element;
  if (rubric.attributes === undefined) {
    return true;
  }
  HTMLelement = document.querySelectorAll(element);
  for (let j = 0; j < rubric.attributes.length; j++) {
    if (rubric.attributes[j].indexOf("||") !== -1) {
      let attributes = attributes[j].split("||");
      for (let i = 0; i < attributes.length; i++) {
        if (HTMLelement[k].hasAttribute(attributes[i]) == true) {
          return true;
        }
      }
      return false;
    }
    if (HTMLelement[k].hasAttribute(rubric.attributes[j]) == false) {
      if (rubric.levelUp == false) {
        return false;
      }
    }
  }
  return true;
}
```

Even when the attribute checking function is fixed, it's still impossible to get full points because the styles test will fail in all cases. (unless i'm missing something completely obscure)

The problem isn't in the function itself, but the styling criteria:

`styles: [["backgroundColor", "rgb (200, 200, 200)"]]`

There is no CSS in milestone 3 to set the background color of images to this specific color scheme, and we're not meant to make our own CSS code at this point in the project. Even if we were to make CSS to pass, the value of the style cannot be achieved when we use the function `getComputedStyle` on the element.

If we make the background color `rgb(200, 200, 200)` then the program will check if the value is **included** in the computed style. However, the space between rgb and its parameters makes that a style that cannot be achieved. Either way, I removed the styling criteria in my pull request because the images don't have any background color applied to them.